### PR TITLE
Fix isError() return type

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/Linkurious/linkurious-rest-client#readme",
   "scripts": {
-    "prepare": "echo 'NPM RUN PREPARE RC'; tsc",
+    "prepare": "tsc",
     "build": "tsc",
     "tsc": "tsc",
     "lint": "eslint --fix --ext .ts .",

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -72,13 +72,13 @@ export class Response<B> {
     return this.status >= 200 && this.status < 300;
   }
 
-  public isError<E extends LkErrorKey, Anything, R extends Response<Anything>>(
+  public isError<E extends LkErrorKey, R extends Response<unknown>>(
     this: R,
     key: E
   ): this is LkErrorKeyToInterface[E] extends PossibleBodies<R>
     ? Response<LkErrorKeyToInterface[E]>
     : never {
-    return hasValue(this.body) && ((this.body as unknown) as LkError).key === key;
+    return hasValue(this.body) && (this.body as LkError).key === key;
   }
 }
 

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -72,10 +72,11 @@ export class Response<B> {
     return this.status >= 200 && this.status < 300;
   }
 
-  public isError<R extends Response<unknown>, E extends AsLkErrorKey<PossibleErrorKeys<R>>>(
+  public isError<R extends Response<unknown>, E extends LkErrorKey>(
     this: R,
-    key: E
-  ): this is PossibleErrorKeys<R> extends E ? never : Response<LkErrorKeyToInterface[E]> {
+    // I found out that extending in the params like this surprisingly works as a highlighter
+    key: E extends PossibleErrorKeys<R> ? E : PossibleErrorKeys<R>
+  ): this is E extends PossibleErrorKeys<R> ? Response<LkErrorKeyToInterface[E]> : never {
     return hasValue(this.body) && (this.body as LkError).key === key;
   }
 }
@@ -89,17 +90,6 @@ export class Response<B> {
 export type ErrorResponses<T extends LkErrorKey> = T extends unknown
   ? Response<LkErrorKeyToInterface[T]>
   : Response<LkErrorKeyToInterface[T]>;
-
-/**
- * Two reasons for this type, which is used in Response.isError():
- *    1) "E extends PossibleErrorKeys<R>>" does not make E extend LkErrorKey, so "LkErrorKeyToInterface[E]" is an error,
- *    but if you do "E extends AsLkErrorKey<PossibleErrorKeys<R>>" then E extends LkErrorKey
- *    (this could be done inside PossibleErrorKeys, but it's done outside because of next reason)
- *    2) If parameter `key: E` is not one of the expected LkErrorKey, E is resolved as union type of all expected LkErrorKey,
- *    but if you do "E extends AsLkErrorKey<PossibleErrorKeys<R>>" then `key` is resolved properly as the LkErrorKey passed
- *    as parameter, only if it's one of the expected expected LkErrorKey otherwise still is resolved as the union type of all expected ones
- */
-export type AsLkErrorKey<T> = T extends LkErrorKey ? T : never;
 
 /**
  * Input:

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -72,7 +72,12 @@ export class Response<B> {
     return this.status >= 200 && this.status < 300;
   }
 
-  public isError<E extends LkErrorKey>(key: E): this is Response<LkError<E>> {
+  public isError<E extends LkErrorKey, Anything, R extends Response<Anything>>(
+    this: R,
+    key: E
+  ): this is LkErrorKeyToInterface[E] extends PossibleBodies<R>
+    ? Response<LkErrorKeyToInterface[E]>
+    : never {
     return hasValue(this.body) && ((this.body as unknown) as LkError).key === key;
   }
 }
@@ -85,6 +90,16 @@ export class Response<B> {
 export type ErrorResponses<T extends LkErrorKey> = T extends unknown
   ? Response<LkErrorKeyToInterface[T]>
   : Response<LkErrorKeyToInterface[T]>;
+
+/**
+ * Input:
+ *    Response<A | B | C> | Response<A> | Response<D> | Response<E>
+ * Output:
+ *    A | B | C | E
+ */
+export type PossibleBodies<R extends {body: unknown}> = R extends {body: infer Bodies}
+  ? Bodies
+  : never;
 
 /**
  * Every error can carry some payload

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -11,7 +11,6 @@ import {hasValue} from '../utils';
 import {SearchSyntaxError} from '../api/Search';
 
 import {FetchConfig} from './types';
-import {Visualization} from "../api/Visualization";
 
 export enum LkErrorKey {
   // Not a server error, thrown internally by the rest-client

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -95,7 +95,7 @@ export type ErrorResponses<T extends LkErrorKey> = T extends unknown
  * Input:
  *    Response<A | B | C> | Response<A> | Response<D> | Response<E>
  * Output:
- *    A | B | C | E
+ *    A | B | C | D | E
  */
 export type PossibleBodies<R extends {body: unknown}> = R extends {body: infer Bodies}
   ? Bodies


### PR DESCRIPTION
Now when:
```ts
const response: Response<UnauthorizedError> | Response<NotFoundError> | Response<CustomAction[]>;

if (response.isError(LkErrorKey.UNAUTHORIZED)) {
  response; // <- Response<UnauthorizedError> (behaves the same)
}

// New: `LkErrorKey.FORBIDDEN` is underlined with red and says that
// it is not assignable to `LkErrorKey.UNAUTHORIZED | LkErrorKey.NOT_FOUND`
if (response.isError(LkErrorKey.FORBIDDEN)) {
  // New: type of `response` is now `never` (before it was `Response<ForbiddenError> & typeof response`)
  response;
}
```



