### PR TITLE
Merge develop-stable into develop [ci:run]

### DIFF
--- a/src/api/DataSource/types.ts
+++ b/src/api/DataSource/types.ts
@@ -4,7 +4,7 @@
  * - Created on 2019-10-25.
  */
 
-import {ICaptions, IDataSourceDefaultStyles} from '../displayTypes';
+import {ICaptions, IDataSourceDefaultStyles, IPropertiesOrder} from '../displayTypes';
 import {IDataSourceParams} from '../commonTypes';
 import {GraphQueryDialect} from '../GraphQuery';
 
@@ -78,6 +78,7 @@ export interface DataSourceUserInfo {
   features: DataSourceFeatures;
   defaultStyles?: IDataSourceDefaultStyles; // defined if withStyles or withCaptions was set to true in the request and the data-source is connected
   defaultCaptions?: ICaptions;
+  defaultPropertiesOrder: IPropertiesOrder; // The default properties order is always defined and will be an empty object if it has not been set by an admin
   settings: DataSourceSettings | ConnectedDataSourceSettings;
   // indexState is undefined for data-sources with a state other than Ready
   indexState?: IndexState;
@@ -86,6 +87,7 @@ export interface DataSourceUserInfo {
 export interface ISetDefaultSourceStylesParams extends IDataSourceParams {
   styles?: IDataSourceDefaultStyles;
   captions?: ICaptions;
+  propertiesOrder?: IPropertiesOrder;
 }
 
 export interface IResetSourceStylesParams extends IDataSourceParams {

--- a/src/api/displayTypes.ts
+++ b/src/api/displayTypes.ts
@@ -162,3 +162,8 @@ export interface ICaptions {
   nodes: GenericObject<ICaption>;
   edges: GenericObject<ICaption>;
 }
+
+export interface IPropertiesOrder {
+  node: GenericObject<string[]>;
+  edge: GenericObject<string[]>;
+}


### PR DESCRIPTION
* LKE-4395 Properties order

https://linkurious.atlassian.net/browse/LKE-4395

* LEK-4395 datasource user info

* lint

* Update types.ts

* Update displayTypes.ts

* Post review: Always defined properties order

The default properties order is always defined and will be an empty object if it has not been set by an admin