### PR TITLE
LKE-2955 feature (datasource): persist sourceKey in configuration

### DIFF
--- a/src/api/Config/types.ts
+++ b/src/api/Config/types.ts
@@ -133,7 +133,7 @@ export type SelectedDataSourceConfig =
 
 export interface IDataSourceConfig<G = IGraphVendorConfig, I = IVendorConfig> {
   name?: string;
-  manualSourceKey?: string;
+  sourceKey?: string;
   readOnly?: boolean;
   graphdb: G;
   index: I;


### PR DESCRIPTION
Data-source configuration has a `manualSourceKey` which is manually edited and override the computed `sourceKey` when set. This feature:
* Rename the `manualSourceKey` configuration field to `sourceKey`.
* Automatically set the `sourceKey` when successfully connecting to a datasource for the first time.

So persisting the `sourceKey` in configuration becomes the default behaviour and no longer requires manual action from the user.