### PR TITLE
Merge develop-stable into develop [ci:run]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ nodeJob {
   projectName = "linkurious/linkurious-rest-client"
   podTemplateNames = ['jnlp-agent-node']
 
-  runForwardMerge = false
+  runForwardMerge = true
 
   createGitTag = true
   gitTagPrefix = 'v'


### PR DESCRIPTION
- JSL-112: disable ForwardMerge
- LKE-6042: Remove npm from the engines section (#416)
- re-activate forward merge
