### PR TITLE
Merge develop-stable into develop [ci:run]

### DIFF
--- a/src/api/Alert/index.ts
+++ b/src/api/Alert/index.ts
@@ -41,7 +41,9 @@ import {
   IBasicUser,
   ICasePreview,
   IGetAllAlertUsersParams,
-  IBulkAssignCasesParams
+  IBulkAssignCasesParams,
+  ISetFullCaseListPreferencesParams,
+  IGetFullCaseListPreferencesResponse
 } from './types';
 
 export * from './types';
@@ -380,6 +382,33 @@ export class AlertAPI extends Request {
       errors: [FEATURE_DISABLED, UNAUTHORIZED, DATA_SOURCE_UNAVAILABLE, FORBIDDEN, NOT_FOUND],
       url: '/:sourceKey/alerts/:alertId/cases/:caseId/preview',
       method: 'GET',
+      params: params
+    });
+  }
+
+  /**
+   * Get UCL preferences of current user for a given data source.
+   */
+  public getFullCaseListPreferences(
+    this: Request<IGetFullCaseListPreferencesResponse>,
+    params: IDataSourceParams
+  ) {
+    return this.request({
+      errors: [UNAUTHORIZED, DATA_SOURCE_UNAVAILABLE, FORBIDDEN, NOT_FOUND],
+      url: '/:sourceKey/alerts/cases/list/preferences',
+      method: 'GET',
+      params: params
+    });
+  }
+
+  /**
+   * Set UCL preferences of current user for a given data source.
+   */
+  public setFullCaseListPreferences(params: ISetFullCaseListPreferencesParams) {
+    return this.request({
+      errors: [UNAUTHORIZED, DATA_SOURCE_UNAVAILABLE, FORBIDDEN, NOT_FOUND],
+      url: '/:sourceKey/alerts/cases/list/preferences',
+      method: 'PUT',
       params: params
     });
   }

--- a/src/api/Alert/types.ts
+++ b/src/api/Alert/types.ts
@@ -309,3 +309,24 @@ export interface ICasePreview extends Omit<IFullCase, 'statusChangedOn' | 'statu
 export interface IGetAllAlertUsersParams extends IDataSourceParams {
   mutualAlertIds?: number[];
 }
+
+export interface IFullCaseListFilters {
+  alertIds?: number[];
+  caseStatuses?: CaseStatus[];
+  assignedUserIds?: number[];
+  alertFolderIds?: number[];
+}
+
+export interface IFullCaseListPreferences {
+  filters: IFullCaseListFilters;
+  sortBy: FullCaseListSortBy[];
+}
+
+export interface IGetFullCaseListPreferencesResponse extends IFullCaseListPreferences {
+  userId: number;
+  sourceKey: string;
+}
+
+export interface ISetFullCaseListPreferencesParams
+  extends IDataSourceParams,
+    IFullCaseListPreferences {}


### PR DESCRIPTION
* bumping to v3.2.0

* LKE-6144 feat: Add UCL preferences to user preferences

* Export type of unifiedCaseListPreferences as a separate interface

* Add default unifiedCaseListPreferences to config types

* Reuse UCL preferences type for default prefs

* Add property in preferences to filter cases by folder

* make case status filter optional

* LKE-6144 rename alertFolderFilter

* Revert "Merge branch 'develop' into LKE-6144-user-lands-on-the-last-state-of-their-filtered-sorted-ucl-when-they-access-it"

This reverts commit b363fe05353bf9c5a17b16938977cf67554e5fd2, reversing
changes made to 552d0bdd7e20d83b2f36fbc278d04eb1c3dd9aca.

* LKE-6144 fix node version

* Roll back merging develop into this branch

* Realign work on UCL preferences with specs

* Remove default UCL prefs from config

* Rename references to UCL to FullCaseList

* Simpler interface layout for UCL preferences

Co-authored-by: Edward Nys <edward@linkurio.us>
Co-authored-by: david <david@linkurio.us>
Co-authored-by: linkurious-infra <64854571+linkurious-infra@users.noreply.github.com>
Co-authored-by: Cheick Diarra <cheickdiarra74@gmail.com>
Co-authored-by: Eric Mallard <eric.delavarende@linkurio.us>
Co-authored-by: mzorkany <mahmoud@linkurio.us>