### PR TITLE
LKE-7620 Public spaces

### DIFF
--- a/src/api/spaces/types.ts
+++ b/src/api/spaces/types.ts
@@ -5,12 +5,13 @@
  * - Created on 2022-08-04.
  */
 
-import {IDataSourceParams, PersistedItem, SortDirection} from '../commonTypes';
+import { IDataSourceParams, PersistedItem, SharingMode, SortDirection } from '../commonTypes';
 
 export interface ICreateSpaceParams extends IDataSourceParams {
   title: string;
   description?: string;
-  sharedWithGroups: number[];
+  sharing?: SharingMode.SOURCE |  SharingMode.GROUPS
+  sharedWithGroups?: number[];
 }
 
 export interface IUpdateSpaceParams extends ICreateSpaceParams {

--- a/src/api/spaces/types.ts
+++ b/src/api/spaces/types.ts
@@ -5,12 +5,12 @@
  * - Created on 2022-08-04.
  */
 
-import { IDataSourceParams, PersistedItem, SharingMode, SortDirection } from '../commonTypes';
+import {IDataSourceParams, PersistedItem, SharingMode, SortDirection} from '../commonTypes';
 
 export interface ICreateSpaceParams extends IDataSourceParams {
   title: string;
   description?: string;
-  sharing?: SharingMode.SOURCE |  SharingMode.GROUPS
+  sharing?: SharingMode.SOURCE | SharingMode.GROUPS;
   sharedWithGroups?: number[];
 }
 


### PR DESCRIPTION
fixes: https://linkurious.atlassian.net/browse/LKE-7620

This PR allows us the frontend and backend to declare that space is shared publicly.

- We add 1 additional parameter `sharing`, this allows us to declare the sharing mode
- We make `sharedWithGroups` & `sharing` optional, this allows us to be retro-compatible with the existing implementation
- This PR can be merged safely and will not break the backend or frontend

Since `sharing` is optional we need a default option, this will be implemented by the backend.
The frontend will use the option `sharing=SharingMode.SOURCE` to declare a space as public.