### PR TITLE
LKE-7814: Update to Typescript 4.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,7 @@
         "mocha-multi-reporters": "1.5.1",
         "nyc": "15.1.0",
         "prettier": "2.2.1",
-        "ts-node": "8.8.1",
-        "typescript": "4.6.3"
+        "typescript": "4.8.4"
       },
       "engines": {
         "node": "16.19.0"
@@ -1116,13 +1115,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://nexus3.linkurious.net/repository/npm/argparse/-/argparse-1.0.10.tgz",
@@ -1269,13 +1261,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/caching-transform": {
       "version": "4.0.0",
@@ -3665,13 +3650,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://nexus3.linkurious.net/repository/npm/md5/-/md5-2.3.0.tgz",
@@ -4903,27 +4881,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/spawn-wrap": {
       "version": "2.0.0",
       "resolved": "https://nexus3.linkurious.net/repository/npm/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
@@ -5148,42 +5105,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/ts-node": {
-      "version": "8.8.1",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/ts-node/-/ts-node-8.8.1.tgz",
-      "integrity": "sha512-10DE9ONho06QORKAaCBpPiFCdW+tZJuY/84tyypGtl6r+/C7Asq0dhqbRZURuUlLQtZxxDvT8eoj8cGW0ha6Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "arg": "^4.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.6",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.7"
-      }
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://nexus3.linkurious.net/repository/npm/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -5277,9 +5198,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.8.4",
+      "resolved": "https://nexus3.linkurious.net/repository/npm/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5627,16 +5548,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -6425,12 +6336,6 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://nexus3.linkurious.net/repository/npm/argparse/-/argparse-1.0.10.tgz",
@@ -6531,12 +6436,6 @@
         "escalade": "^3.1.1",
         "node-releases": "^1.1.71"
       }
-    },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
     },
     "caching-transform": {
       "version": "4.0.0",
@@ -8161,12 +8060,6 @@
         "semver": "^6.0.0"
       }
     },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
     "md5": {
       "version": "2.3.0",
       "resolved": "https://nexus3.linkurious.net/repository/npm/md5/-/md5-2.3.0.tgz",
@@ -8978,24 +8871,6 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
-    "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://nexus3.linkurious.net/repository/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "spawn-wrap": {
       "version": "2.0.0",
       "resolved": "https://nexus3.linkurious.net/repository/npm/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
@@ -9153,27 +9028,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "ts-node": {
-      "version": "8.8.1",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/ts-node/-/ts-node-8.8.1.tgz",
-      "integrity": "sha512-10DE9ONho06QORKAaCBpPiFCdW+tZJuY/84tyypGtl6r+/C7Asq0dhqbRZURuUlLQtZxxDvT8eoj8cGW0ha6Bg==",
-      "dev": true,
-      "requires": {
-        "arg": "^4.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.6",
-        "yn": "3.1.1"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://nexus3.linkurious.net/repository/npm/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true
-        }
-      }
-    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://nexus3.linkurious.net/repository/npm/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -9243,9 +9097,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.8.4",
+      "resolved": "https://nexus3.linkurious.net/repository/npm/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "unbox-primitive": {
@@ -9494,12 +9348,6 @@
           "dev": true
         }
       }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "mocha-multi-reporters": "1.5.1",
     "nyc": "15.1.0",
     "prettier": "2.2.1",
-    "ts-node": "8.8.1",
-    "typescript": "4.6.3"
+    "typescript": "4.8.4"
   },
   "dependencies": {
     "superagent": "6.1.0"


### PR DESCRIPTION
https://linkurious.atlassian.net/browse/LKE-7814

* This pull request updates `typescript` from 4.6.3 to 4.8.4.
* It also removes the unused dev dependency `ts-node`.