### PR TITLE
LKE-7924 remove max concurrency config and rename maxCasesLimit

### DIFF
--- a/src/api/Config/types.ts
+++ b/src/api/Config/types.ts
@@ -203,8 +203,7 @@ export interface IAzureSearchConfig extends IVendorConfig {
 export interface IAlertsConfig {
   enabled?: boolean;
   maxCasesLimit?: number;
-  maxRuntimeLimit?: number;
-  maxConcurrency?: number;
+  maxMatchesLimit?: number;
 }
 
 export interface IAdvancedConfig {

--- a/src/api/Config/types.ts
+++ b/src/api/Config/types.ts
@@ -202,8 +202,8 @@ export interface IAzureSearchConfig extends IVendorConfig {
 
 export interface IAlertsConfig {
   enabled?: boolean;
-  maxCasesLimit?: number;
   maxMatchesLimit?: number;
+  maxRuntimeLimit?: number;
 }
 
 export interface IAdvancedConfig {


### PR DESCRIPTION
This PR is a part of the alerts enhancement topic

The alerts configs are modified by:
Removing the maxConcurrencyLimit
Renaming maxCasesLimit to maxMatchesLimit

[LKE-7924](https://linkurious.atlassian.net/browse/LKE-7924)
https://linkurious.atlassian.net/browse/LKE-7925

[LKE-7924]: https://linkurious.atlassian.net/browse/LKE-7924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ