### PR TITLE
LKE-12225: Feature flags config

### DIFF
--- a/src/api/Config/types.ts
+++ b/src/api/Config/types.ts
@@ -252,6 +252,7 @@ export interface IAdvancedConfig {
   itemTypeCountLimit?: number;
   dataSourceConnectionTimeout?: number;
   dataSourceAutoReconnectInterval?: number;
+  flags?: GenericObject;
 }
 
 export interface ILeafletConfig {


### PR DESCRIPTION
This cherry-picks https://github.com/Linkurious/linkurious-rest-client/pull/756, so that we can merge it to `develop-stable` without having to wait for https://github.com/Linkurious/linkurious-rest-client/pull/759.