### PR TITLE
LKE-12859 spanner: adding a "var" field in graph-input templates 

### DIFF
--- a/src/api/GraphQuery/queryTemplates.ts
+++ b/src/api/GraphQuery/queryTemplates.ts
@@ -64,6 +64,7 @@ export interface NodeTemplate extends TemplateField<TemplateFieldType.NODE> {
   options?: {
     categories?: string[];
     serialize?: string;
+    var?: string;
   };
 }
 
@@ -71,18 +72,21 @@ export interface NodesetTemplate extends TemplateField<TemplateFieldType.NODE_SE
   options?: {
     categories?: string[];
     serialize?: string;
+    var?: string;
   };
 }
 
 export interface EdgeTemplate extends TemplateField<TemplateFieldType.EDGE> {
   options?: {
     types?: string[];
+    var?: string;
   };
 }
 
 export interface EdgesetTemplate extends TemplateField<TemplateFieldType.EDGE_SET> {
   options?: {
     types?: string[];
+    var?: string;
   };
 }
 


### PR DESCRIPTION
LKE-12859
to be able to set the var name to use for nodes/edges in the node/edge filter statement.