### PR TITLE
LKE-12832: Add the "explain why" entity resolution API

### DIFF
--- a/src/api/entityResolution/index.ts
+++ b/src/api/entityResolution/index.ts
@@ -16,7 +16,9 @@ import {
   EntityResolutionMetrics,
   ExplainWhyEntitiesParams,
   ExplainWhyRecordParams,
+  GetEntityByIdParams,
   IngestionStatus,
+  ResolvedEntity,
   StartEntityResolutionTaskParams,
   UpdateEntityResolutionMappingParams,
   WhyEntities,
@@ -229,6 +231,24 @@ export class EntityResolutionAPI extends Request {
         ENTITY_RESOLUTION_EXPIRED_LICENSE
       ],
       url: '/:sourceKey/entityResolution/why/entities/:entityId/:otherEntityId',
+      method: 'GET',
+      params: params
+    });
+  }
+
+  /**
+   * Explain why two different entities are related.
+   */
+  getEntityById(this: Request<ResolvedEntity>, params: GetEntityByIdParams) {
+    return this.request({
+      errors: [
+        UNAUTHORIZED,
+        FORBIDDEN,
+        DATA_SOURCE_UNAVAILABLE,
+        NOT_FOUND,
+        ENTITY_RESOLUTION_EXPIRED_LICENSE
+      ],
+      url: '/:sourceKey/entityResolution/entities/:entityId',
       method: 'GET',
       params: params
     });

--- a/src/api/entityResolution/index.ts
+++ b/src/api/entityResolution/index.ts
@@ -14,9 +14,13 @@ import {
   EntityResolutionLicenseInfo,
   EntityResolutionMapping,
   EntityResolutionMetrics,
+  ExplainWhyEntitiesParams,
+  ExplainWhyRecordParams,
   IngestionStatus,
   StartEntityResolutionTaskParams,
-  UpdateEntityResolutionMappingParams
+  UpdateEntityResolutionMappingParams,
+  WhyEntities,
+  WhyRecord
 } from './types';
 
 export * from './types';
@@ -189,6 +193,42 @@ export class EntityResolutionAPI extends Request {
     return this.request({
       errors: [UNAUTHORIZED, FORBIDDEN, DATA_SOURCE_UNAVAILABLE],
       url: '/:sourceKey/entityResolution/metrics',
+      method: 'GET',
+      params: params
+    });
+  }
+
+  /**
+   * Explain why a given record resolved to an entity.
+   */
+  explainWhyRecord(this: Request<WhyRecord>, params: ExplainWhyRecordParams) {
+    return this.request({
+      errors: [
+        UNAUTHORIZED,
+        FORBIDDEN,
+        DATA_SOURCE_UNAVAILABLE,
+        NOT_FOUND,
+        ENTITY_RESOLUTION_EXPIRED_LICENSE
+      ],
+      url: '/:sourceKey/entityResolution/why/record/:recordId',
+      method: 'GET',
+      params: params
+    });
+  }
+
+  /**
+   * Explain why two different entities are related.
+   */
+  explainWhyEntities(this: Request<WhyEntities>, params: ExplainWhyEntitiesParams) {
+    return this.request({
+      errors: [
+        UNAUTHORIZED,
+        FORBIDDEN,
+        DATA_SOURCE_UNAVAILABLE,
+        NOT_FOUND,
+        ENTITY_RESOLUTION_EXPIRED_LICENSE
+      ],
+      url: '/:sourceKey/entityResolution/why/entities/:entityId/:otherEntityId',
       method: 'GET',
       params: params
     });

--- a/src/api/entityResolution/index.ts
+++ b/src/api/entityResolution/index.ts
@@ -237,7 +237,7 @@ export class EntityResolutionAPI extends Request {
   }
 
   /**
-   * Explain why two different entities are related.
+   * Get a resolved entity by its ID
    */
   getEntityById(this: Request<ResolvedEntity>, params: GetEntityByIdParams) {
     return this.request({

--- a/src/api/entityResolution/types.ts
+++ b/src/api/entityResolution/types.ts
@@ -445,7 +445,7 @@ interface MatchKey {
   value: string;
   same: EntityAttributeKey[];
   different: EntityAttributeKey[];
-  isAmbiguous: boolean;
+  ambiguous: boolean;
 }
 
 interface MatchScore<T> {
@@ -503,7 +503,7 @@ type EntityAttributeKey =
   | 'WhatsApp'
   | 'Zoom room';
 
-export interface ResolvedEntity extends IDataSourceParams {
+export interface ResolvedEntity {
   id: number;
   name: string;
   type: EntityResolutionRecordType;

--- a/src/api/entityResolution/types.ts
+++ b/src/api/entityResolution/types.ts
@@ -438,7 +438,7 @@ export interface WhyEntities {
   matchScores: MatchScore<ScoredPair>[];
 }
 
-interface MatchKey {
+export interface MatchKey {
   /**
    * The serialized form of the match key, for instance `+NAME+ADDRESS-DOB`.
    */
@@ -453,19 +453,23 @@ interface MatchScore<T> {
   values: T[];
 }
 
-interface ScoredValue {
+export interface Score {
+  percentage: number;
+  bucket: 'SAME' | 'CLOSE' | 'PLAUSIBLE' | 'NO_CHANCE';
+}
+
+export interface ScoredValue {
   value: string;
-  score: {
-    percentage: number;
-    bucket: 'SAME' | 'CLOSE' | 'PLAUSIBLE' | 'NO_CHANCE';
-  };
+  score: Score;
 }
 
-interface ScoredPair extends ScoredValue {
-  otherValue: string;
+export interface ScoredPair {
+  inbound: {id: string; value: string};
+  candidate: {id: string; value: string};
+  score: Score;
 }
 
-type EntityAttributeKey =
+export type EntityAttributeKey =
   | 'Account number'
   | 'Address'
   | 'Citizenship'

--- a/src/api/entityResolution/types.ts
+++ b/src/api/entityResolution/types.ts
@@ -503,7 +503,6 @@ type EntityAttributeKey =
   | 'WhatsApp'
   | 'Zoom room';
 
-// Internal note: this type is also used by LKE's entity resolution client
 export interface ResolvedEntity extends IDataSourceParams {
   id: number;
   name: string;
@@ -529,7 +528,6 @@ export interface EntityResolutionMatch {
   entityResolutionRuleCode: string;
 }
 
-// Internal note: this type is also used by LKE's entity resolution client
 export enum MatchLevel {
   RESOLVED = 'RESOLVED',
   POSSIBLY_SAME = 'POSSIBLY_SAME',

--- a/src/api/entityResolution/types.ts
+++ b/src/api/entityResolution/types.ts
@@ -395,3 +395,100 @@ export interface EntityResolutionMetrics {
    */
   possibleRelationships: number;
 }
+
+export interface ExplainWhyRecordParams extends IDataSourceParams {
+  /**
+   * The ID of the record to explain. It corresponds to the ID of the record node in the graph
+   * database.
+   */
+  recordId: string;
+}
+
+export interface ExplainWhyEntitiesParams extends IDataSourceParams {
+  /**
+   * The ID of the first entity to explain. It corresponds to the `entityId` property of the entity
+   * node in the graph database.
+   */
+  entityId: number;
+  /**
+   * The ID of the other related entity.
+   */
+  otherEntityId: number;
+}
+
+export interface WhyRecord {
+  matchLevelCode: 'RESOLVED';
+  matchKey: MatchKey;
+  matchScores: MatchScore<ScoredValue>[];
+}
+
+export interface WhyEntities {
+  matchLevelCode: 'POSSIBLY_SAME' | 'POSSIBLY_RELATED';
+  matchKey: MatchKey;
+  matchScores: MatchScore<ScoredPair>[];
+}
+
+interface MatchKey {
+  /**
+   * The serialized form of the match key, for instance `+NAME+ADDRESS-DOB`.
+   */
+  value: string;
+  same: EntityAttributeKey[];
+  different: EntityAttributeKey[];
+  isAmbiguous: boolean;
+}
+
+interface MatchScore<T> {
+  key: EntityAttributeKey;
+  values: T[];
+}
+
+interface ScoredValue {
+  value: string;
+  score: {
+    percentage: number;
+    bucket: 'SAME' | 'CLOSE' | 'PLAUSIBLE' | 'NO_CHANCE';
+  };
+}
+
+interface ScoredPair extends ScoredValue {
+  otherValue: string;
+}
+
+type EntityAttributeKey =
+  | 'Account number'
+  | 'Address'
+  | 'Citizenship'
+  | 'Date of birth'
+  | 'Date of death'
+  | 'Driver license'
+  | 'DUNS number'
+  | 'Email'
+  | 'Facebook'
+  | 'Gender'
+  | 'Group association'
+  | 'Instagram'
+  | 'LEI number'
+  | 'LinkedIn'
+  | 'Name'
+  | 'Nationality'
+  | 'National ID'
+  | 'NPI number'
+  | 'Passport'
+  | 'Phone'
+  | 'Place of birth'
+  | 'Record type'
+  | 'Registration country'
+  | 'Registration date'
+  | 'Signal'
+  | 'Social security number'
+  | 'Skype'
+  | 'Tango'
+  | 'Tax ID'
+  | 'Telegram'
+  | 'Twitter'
+  | 'Viber'
+  | 'Website'
+  | 'Wechat'
+  | 'WhatsApp'
+  | 'Zoom room';

--- a/src/api/entityResolution/types.ts
+++ b/src/api/entityResolution/types.ts
@@ -416,15 +416,25 @@ export interface ExplainWhyEntitiesParams extends IDataSourceParams {
   otherEntityId: number;
 }
 
+export interface GetEntityByIdParams extends IDataSourceParams {
+  /**
+   * The ID of the first entity to explain. It corresponds to the `entityId` property of the entity
+   * node in the graph database.
+   */
+  entityId: number;
+}
+
 export interface WhyRecord {
   matchLevelCode: 'RESOLVED';
   matchKey: MatchKey;
+  entityResolutionRuleCode: string;
   matchScores: MatchScore<ScoredValue>[];
 }
 
 export interface WhyEntities {
   matchLevelCode: 'POSSIBLY_SAME' | 'POSSIBLY_RELATED';
   matchKey: MatchKey;
+  entityResolutionRuleCode: string;
   matchScores: MatchScore<ScoredPair>[];
 }
 
@@ -492,3 +502,37 @@ type EntityAttributeKey =
   | 'Wechat'
   | 'WhatsApp'
   | 'Zoom room';
+
+// Internal note: this type is also used by LKE's entity resolution client
+export interface ResolvedEntity extends IDataSourceParams {
+  id: number;
+  name: string;
+  type: EntityResolutionRecordType;
+  records: EntityRecord[];
+  relatedEntities: RelatedEntity[];
+}
+
+export interface EntityRecord extends EntityResolutionMatch {
+  id: string;
+}
+
+export interface RelatedEntity extends EntityResolutionMatch {
+  id: number;
+  name: string;
+  ambiguous: boolean;
+}
+
+export interface EntityResolutionMatch {
+  matchKey: MatchKey;
+  matchLevel: number;
+  matchLevelCode: `${MatchLevel}`;
+  entityResolutionRuleCode: string;
+}
+
+// Internal note: this type is also used by LKE's entity resolution client
+export enum MatchLevel {
+  RESOLVED = 'RESOLVED',
+  POSSIBLY_SAME = 'POSSIBLY_SAME',
+  POSSIBLY_RELATED = 'POSSIBLY_RELATED'
+  // These are known match level codes, some might be added later
+}


### PR DESCRIPTION
https://linkurious.atlassian.net/browse/LKE-12832

This pull request adds some three resolution endpoints:
* explain why a record resolved to an entity.
* explain why two entities are related.
* retrieve the details of an entity
  * The list of its records ("Matched records").
  * The other entities that are possibly same ("Possible match" / "POSSIBLY_SAME") or possibly related ("Possible relationships" / "POSSIBLY_RELATED").

The "GET entity detail by entity Id" endpoint is one possible solution that basically does a "node expand" under the hood. 
* pros: it's straighforward and accurate. It includes results that may not be part of the visualization.
* cons: it has to be called by the frontend when the "Entity resolution" panel is displayed, which may induce some latency.

Otherwise, we might consider adding these entity resolution details in the "GET visualization" endpoint response and eagerly loading them for all the entities of the viz at once. I suspect this is a bad idea. In particular, it could be computationally taxing if the viz is large and/or contains many entities.