### PR TITLE
LKE-11587  User Update: Add FEATURE_DISABLED to errors list

### DIFF
--- a/src/api/User/index.ts
+++ b/src/api/User/index.ts
@@ -35,6 +35,7 @@ import {
 export * from './types';
 
 const {
+  FEATURE_DISABLED,
   UNAUTHORIZED,
   DATA_SOURCE_UNAVAILABLE,
   FORBIDDEN,
@@ -106,6 +107,7 @@ export class UserAPI extends Request {
   public updateUser(this: Request<User>, params: IUpdateUserParams) {
     return this.request({
       errors: [
+        FEATURE_DISABLED,
         UNAUTHORIZED,
         FORBIDDEN,
         NOT_IMPLEMENTED,


### PR DESCRIPTION
LKE-11587

When a user is from source SSO with `access.autoRefreshGroupMapping` settings, their groups can't be changed, and return a FEATURE_DISABLED type of error that was not part of the expected list, preventing the frontend from catching that error and displaying proper error messaging.