### PR TITLE
LKE-13332: Remove the no longer used matchLevel field

### DIFF
--- a/src/api/entityResolution/types.ts
+++ b/src/api/entityResolution/types.ts
@@ -530,7 +530,6 @@ export interface RelatedEntity extends EntityResolutionMatch {
 
 export interface EntityResolutionMatch {
   matchKey: MatchKey;
-  matchLevel: number;
   matchLevelCode: `${MatchLevel}`;
   entityResolutionRuleCode: string;
 }


### PR DESCRIPTION
This field is actually no longer used, this pull request simply fixes the type definition.