### PR TITLE
LKE-14701: Add the import graph API

### DIFF
--- a/src/api/Visualization/types.ts
+++ b/src/api/Visualization/types.ts
@@ -356,7 +356,8 @@ export enum PopulateType {
   SEARCH_NODE = 'searchNodes',
   SEARCH_EDGE = 'searchEdges',
   PATTERN = 'pattern',
-  CASE_ID = 'caseId'
+  CASE_ID = 'caseId',
+  IMPORT_ID = 'importId'
 }
 
 export interface IGetVisualizationTreeParams extends IDataSourceParams {

--- a/src/api/import/index.ts
+++ b/src/api/import/index.ts
@@ -6,12 +6,14 @@
  */
 import {Request} from '../../http/request';
 import {LkErrorKey} from '../../http/response';
+import {LkSubGraph} from '../graphItemTypes';
 
 import {
   CreateImportParams,
   CreateImportTemplateParams,
   DeleteImportParams,
   DeleteImportTemplateParams,
+  getImportGraphParams,
   GetImportsParams,
   GetImportTemplatesParams,
   Import,
@@ -104,6 +106,18 @@ export class ImportAPI extends Request {
     return this.request({
       errors: [UNAUTHORIZED, FORBIDDEN, DATA_SOURCE_UNAVAILABLE],
       url: '/:sourceKey/imports',
+      method: 'GET',
+      params: params
+    });
+  }
+
+  /**
+   * Get the nodes and/or edges imported by a given import.
+   */
+  getImportGraph(this: Request<LkSubGraph>, params: getImportGraphParams) {
+    return this.request({
+      errors: [UNAUTHORIZED, FORBIDDEN, DATA_SOURCE_UNAVAILABLE, NOT_FOUND],
+      url: '/:sourceKey/imports/:id/graph',
       method: 'GET',
       params: params
     });

--- a/src/api/import/types.ts
+++ b/src/api/import/types.ts
@@ -87,6 +87,8 @@ export interface ImportTemplate extends CreateImportTemplateParams {
 }
 
 export interface CreateImportParams extends IDataSourceParams {
+  name: string;
+  description?: string;
   /**
    * Filename of the uploaded file (including its extension).
    */
@@ -101,11 +103,15 @@ export interface DeleteImportParams extends IDataSourceParams {
   id: number;
 }
 
+export type getImportGraphParams = DeleteImportParams;
+
 export type GetImportsParams = IDataSourceParams;
 
 export interface Import {
   id: number;
   sourceKey: string;
+  name: string;
+  description?: string;
   filename: string;
   entityType: EntityType;
   /**


### PR DESCRIPTION
## API Draft for https://linkurious.atlassian.net/browse/LKE-14701

* Add the option to populate a visualization sandbox by import ID. Used to add imported data to a new visualization.

* Add a new endpoint to get the imported graph for a given import ID. Used to add imported data to an existing visualization.

* Add `name` and `description` properties to the imports.

## Comments

* I assume that the frontend can use `GET /api/:sourceKey/visualizations/tree` to fetch visualizations for the dropdown list of the existing visualizations.

* We implement no limit / pagination on the new "get imported graph" endpoint or to populate a visualization sandbox by import ID. 
  * That might be an issue for large imports, albeit the actual limits aren't clear and may vary. Product is inform and OK with that. 
  * We'll display a warning banner in the UI: `Adding more than X entities at once is overwhelming. The process might take a few minutes.`. With X being 500 (constant - not configurable).

* In the backend, we'll need to add two new GraphDAO methods to get nodes/edges by property.
  * We implement these methods only on Neo4j and Memgraph.
  * We introduce a graph feature flag that completely hides the CSV import feature for other graph vendors.

* Legacy imports don't have a name. For these, the name will be an empty string.

* In the backend, the support for alternative IDs should be transparent.