### PR TITLE
LKE-14806 feat(Frontend API) Initial setup

### DIFF
--- a/src/frontendApiTypes.ts
+++ b/src/frontendApiTypes.ts
@@ -1,0 +1,46 @@
+/**
+ * LINKURIOUS CONFIDENTIAL
+ * Copyright Linkurious SAS 2012 - 2026
+ *
+ * - Created on 2026-04-15.
+ */
+
+export interface BaseFrontendApiCall {
+  kind: 'LinkuriousFrontendApiCall';
+  method: string;
+  methodVersion: number;
+  methodParams?: {};
+}
+
+export interface FrontendApiRefreshQueries extends BaseFrontendApiCall {
+  method: 'SavedGraphQueries.refresh';
+  methodVersion: 1;
+}
+
+export interface FrontendApiCloseModal extends BaseFrontendApiCall {
+  method: 'CustomActionModal.close';
+  methodVersion: 1;
+}
+
+export type FrontendApiCall = FrontendApiRefreshQueries | FrontendApiCloseModal;
+
+export function isFrontendApiCall(o: unknown): o is FrontendApiCall {
+  return (
+    o !== null &&
+    o !== undefined &&
+    typeof o === 'object' &&
+    'kind' in o &&
+    (o as BaseFrontendApiCall).kind === 'LinkuriousFrontendApiCall'
+  );
+}
+
+export function checkMethodVersion<T extends FrontendApiCall>(
+  call: T,
+  expectedVersion: T['methodVersion']
+): void {
+  if (call.methodVersion !== expectedVersion) {
+    throw new Error(
+      `FrontendApi: Unexpected version ${call.methodVersion as number} for method ${call.method as string} (expected ${expectedVersion as number})`
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,5 +34,6 @@ export * from './http/request';
 export * from './http/response';
 export * from './http/types';
 export * from './errorListener';
+export * from './frontendApiTypes';
 export * from './restClient';
 export * from './utils';


### PR DESCRIPTION
LKE-14806

Solution proposed by David to have in Rest Client the interface and types for a Plugin->Frontend communication format : https://linkurious.atlassian.net/browse/LKE-14722?focusedCommentId=88810

What this implements is types and utility methods to define the structure for messages that are sent from plugins to LKE using `window.postMessage` which is implemented right now for refreshing Queries List after saving a query in Query AI and closing the modal, but could also be used to have a cleaner way to add nodes to a current viz for example.

Utility methods are included to check that message receives are LKE Plugin messages (browser plugins among other things use postMessage quite a lot so that's a first filter) and check each method's compatibility between plugin and frontend (in case the expected params structure for a method changes, its version must be changed).