### PR TITLE
LKE-14776: Stop exporting utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,4 +35,3 @@ export * from './http/response';
 export * from './http/types';
 export * from './errorListener';
 export * from './restClient';
-export * from './utils';


### PR DESCRIPTION
https://linkurious.atlassian.net/browse/LKE-14776

Stop exporting utils.

It's only used in shared, since https://github.com/Linkurious/linkurious-shared/pull/538. So this has not been published on npm, it's safe to delete it.

See also related PR https://github.com/Linkurious/linkurious-server/pull/6179.